### PR TITLE
Read file contents and encode as base64 string

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ Arguments are provided as inputs to the resource, in the `*.tf` file.
 
 Attributes are values that are only known after creation.
 
+- `base64contents` `(string)` - the contents of the file as a base64 encoded
+  string. Useful for binary files.
+
 - `contents` `(string)` - the contents of the file as a string. Contents are
   converted to a string, so it is not recommended you use this resource on
   binary files.

--- a/filesystem/helpers.go
+++ b/filesystem/helpers.go
@@ -65,6 +65,7 @@ func expandRelativePath(p, root string) (string, error) {
 
 type fileStat struct {
 	name     string
+	bytes    []byte
 	contents string
 	size     int64
 	mode     string
@@ -97,6 +98,7 @@ func readFileAndStats(p string) (*fileStat, error) {
 
 	return &fileStat{
 		name:     stat.Name(),
+		bytes:    contents,
 		contents: string(contents),
 		size:     stat.Size(),
 		mode:     fmt.Sprintf("%#o", stat.Mode()),

--- a/filesystem/resource_file_reader.go
+++ b/filesystem/resource_file_reader.go
@@ -16,6 +16,8 @@
 package filesystem
 
 import (
+	"encoding/base64"
+
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -44,9 +46,16 @@ func resourceFileReader() *schema.Resource {
 			//
 			// Computed values
 			//
+			"base64contents": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "Raw file contents converted to a base64 encoded string",
+				Computed:    true,
+				Sensitive:   true,
+			},
+
 			"contents": &schema.Schema{
 				Type:        schema.TypeString,
-				Description: "Raw file contents",
+				Description: "Raw file contents converted to a string",
 				Computed:    true,
 				Sensitive:   true,
 			},
@@ -98,7 +107,10 @@ func resourceFileReaderRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	b64 := base64.StdEncoding.EncodeToString(stat.bytes)
+
 	d.Set("name", stat.name)
+	d.Set("base64contents", b64)
 	d.Set("contents", stat.contents)
 	d.Set("size", stat.size)
 	d.Set("mode", stat.mode)

--- a/filesystem/resource_file_reader_test.go
+++ b/filesystem/resource_file_reader_test.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -16,6 +17,7 @@ func TestFileSystemFileReader(t *testing.T) {
 		t.Parallel()
 
 		contents := "This is some content!"
+		base64contents := base64.StdEncoding.EncodeToString([]byte(contents))
 
 		f, err := ioutil.TempFile("", "")
 		if err != nil {
@@ -59,6 +61,9 @@ func TestFileSystemFileReader(t *testing.T) {
 							t.Errorf("expected %q to be %q", act, exp)
 						}
 						if act, exp := attrs["contents"], contents; act != exp {
+							t.Errorf("expected %q to be %q", act, exp)
+						}
+						if act, exp := attrs["base64contents"], base64contents; act != exp {
 							t.Errorf("expected %q to be %q", act, exp)
 						}
 						return nil


### PR DESCRIPTION
I wanted to mount a certificate file that was generated during a terraform apply as a secret in base64 encoded format. 

I'm not sure if the fileSizeLimit should be adjusted to account for this change. It is currently:

```
	if stat.Size() > fileSizeLimit {
		return nil, errors.New("file is too large (> 1GiB)")
	
```